### PR TITLE
Fixed a bug in World Tick Group Registration

### DIFF
--- a/Source/Engine/Nessie/Scene/TickFunction.cpp
+++ b/Source/Engine/Nessie/Scene/TickFunction.cpp
@@ -141,5 +141,6 @@ namespace nes
         m_pTickGroup = nullptr;
         m_pNextTick = nullptr;
         m_relativeTickCooldown = 0.f;
+        m_lastTimeTicked = -1.f;
     }
 }

--- a/Source/Engine/Nessie/World/Components/FreeCamMovementComponent.cpp
+++ b/Source/Engine/Nessie/World/Components/FreeCamMovementComponent.cpp
@@ -13,6 +13,7 @@ namespace nes
     {
         m_rotationEnabled = false;
         auto* pWorld = GetOwner()->GetWorld();
+        //m_tickFunction.SetTickInterval(5.f);
         pWorld->RegisterTickToWorldTickGroup(&m_tickFunction, TickStage::PrePhysics);
         
         return TickableEntity3DComponent::Init();
@@ -101,6 +102,7 @@ namespace nes
 
     void FreeCamMovementComponent::Tick(const float deltaTime)
     {
+        //NES_LOG("Ticked. Delta Time: ", deltaTime);
         ProcessInput();
         const Vector3 deltaPitchYawRoll = Vector3(m_inputRotation.x * m_turnSpeedPitch, m_inputRotation.y * m_turnSpeedYaw, 0.f) * deltaTime;
         const Vector3 deltaMovement = m_inputMovement * (m_moveSpeed * deltaTime);

--- a/Source/Engine/Nessie/World/World.cpp
+++ b/Source/Engine/Nessie/World/World.cpp
@@ -33,19 +33,19 @@ namespace nes
         switch (stage)
         {
             case TickStage::PrePhysics:
-                m_prePhysicsTickGroup.AddTickFunction(pFunction);
+                pFunction->RegisterTick(&m_prePhysicsTickGroup);
                 break;
             
             case TickStage::Physics:
-                m_physicsTickGroup.AddTickFunction(pFunction);
+                pFunction->RegisterTick(&m_physicsTickGroup);
                 break;
             
             case TickStage::PostPhysics:
-                m_postPhysicsTickGroup.AddTickFunction(pFunction);
+                pFunction->RegisterTick(&m_postPhysicsTickGroup);
                 break;
             
             case TickStage::Late:
-                m_lateTickGroup.AddTickFunction(pFunction);
+                pFunction->RegisterTick(&m_lateTickGroup);
                 break;
             
             default:


### PR DESCRIPTION
When I was registering to a Tick Group, I didn't go through the TickFunction, so it was never actually set as registered, then it wasn't properly removed when closing the game.