### PR TITLE
DeviceBufferRange, Updated Vertex/Index Buffers

### DIFF
--- a/Source/Engine/Nessie/Graphics/CommandBuffer.cpp
+++ b/Source/Engine/Nessie/Graphics/CommandBuffer.cpp
@@ -341,12 +341,12 @@ namespace nes
         m_buffer.setScissor(0, vkScissors);
     }
 
-    void CommandBuffer::BindIndexBuffer(const IndexBufferDesc& desc)
+    void CommandBuffer::BindIndexBuffer(const IndexBufferRange& desc)
     {
-        m_buffer.bindIndexBuffer(desc.m_pBuffer->GetVkBuffer(), desc.m_offset, GetVkIndexType(desc.m_indexType));
+        m_buffer.bindIndexBuffer(desc.GetBuffer()->GetVkBuffer(), desc.GetOffset(), GetVkIndexType(desc.GetIndexType()));
     }
 
-    void CommandBuffer::BindVertexBuffers(const vk::ArrayProxy<nes::VertexBufferDesc>& buffers, const uint32 firstBinding)
+    void CommandBuffer::BindVertexBuffers(const vk::ArrayProxy<VertexBufferRange>& buffers, const uint32 firstBinding)
     {
         // [TODO]: Stack allocate each array.
         const uint32 bufferCount = buffers.size();
@@ -357,15 +357,15 @@ namespace nes
 
         for (uint32 i = 0; i < bufferCount; ++i)
         {
-            const VertexBufferDesc& vertexBufferDesc = *(buffers.begin() + i);
-            const DeviceBuffer* pBuffer = vertexBufferDesc.m_pBuffer;
+            const VertexBufferRange& vertexBufferDesc = *(buffers.begin() + i);
+            const DeviceBuffer* pBuffer = vertexBufferDesc.GetBuffer();
 
             if (pBuffer)
             {
                 vkBuffers[i] = pBuffer->GetVkBuffer();
-                vkOffsets[i] = vertexBufferDesc.m_offset;
-                vkSizes[i] = pBuffer->GetDesc().m_size - vertexBufferDesc.m_offset;
-                vkStrides[i] = vertexBufferDesc.m_stride;
+                vkOffsets[i] = vertexBufferDesc.GetOffset();
+                vkSizes[i] = vertexBufferDesc.GetSize();
+                vkStrides[i] = vertexBufferDesc.GetStride();
             }
             else
             {

--- a/Source/Engine/Nessie/Graphics/CommandBuffer.h
+++ b/Source/Engine/Nessie/Graphics/CommandBuffer.h
@@ -105,12 +105,12 @@ namespace nes
         //----------------------------------------------------------------------------------------------------
         /// @brief : Set the index buffer to use for the next DrawIndexed() call.
         //----------------------------------------------------------------------------------------------------
-        void                    BindIndexBuffer(const IndexBufferDesc& desc);
+        void                    BindIndexBuffer(const IndexBufferRange& desc);
 
         //----------------------------------------------------------------------------------------------------
         /// @brief : Bind the vertex buffers used for the next draw call. 
         //----------------------------------------------------------------------------------------------------
-        void                    BindVertexBuffers(const vk::ArrayProxy<nes::VertexBufferDesc>& buffers, const uint32 firstBinding = 0);  
+        void                    BindVertexBuffers(const vk::ArrayProxy<VertexBufferRange>& buffers, const uint32 firstBinding = 0);  
 
         //----------------------------------------------------------------------------------------------------
         /// @brief : Submit a set of vertices to be drawn - the vertices are either directly in the shader for

--- a/Source/Engine/Nessie/Graphics/DataUploader.cpp
+++ b/Source/Engine/Nessie/Graphics/DataUploader.cpp
@@ -48,8 +48,8 @@ namespace nes
         CopyBufferDesc copyDesc;
         copyDesc.m_dstBuffer = &buffer;
         copyDesc.m_dstOffset = desc.m_uploadOffset;
-        copyDesc.m_srcBuffer = stagingRange.m_buffer;
-        copyDesc.m_srcOffset = stagingRange.m_offset;
+        copyDesc.m_srcBuffer = stagingRange.GetBuffer();
+        copyDesc.m_srcOffset = stagingRange.GetOffset();
         copyDesc.m_size = size;
         m_copyBufferDescs.emplace_back(copyDesc);
     }
@@ -100,17 +100,13 @@ namespace nes
         {
             std::memcpy(stagingBuffer.m_pMappedMemory, pData, dataSize);
         }
-
-        // Set Range Info:
-        outRange.m_offset = 0;
-        outRange.m_range = dataSize;
-        outRange.m_deviceAddress = stagingBuffer.m_deviceAddress;
-        outRange.m_pMapping = stagingBuffer.m_pMappedMemory;
-
+        
         // Add the staging resource to the array:
         m_stagingResourcesSize += dataSize;
         m_stagingResources.emplace_back(std::move(stagingBuffer), semaphoreState);
-        outRange.m_buffer = &(m_stagingResources.back().m_buffer);
+        
+        // Set the Range:
+        outRange = DeviceBufferRange(&(m_stagingResources.back().m_buffer), 0, dataSize);
     }
 
     void DataUploader::ClearPending()

--- a/Source/Engine/Nessie/Graphics/DataUploader.h
+++ b/Source/Engine/Nessie/Graphics/DataUploader.h
@@ -18,20 +18,6 @@ namespace nes
     };
 
     //----------------------------------------------------------------------------------------------------
-    // [TODO]: Move to Device Buffer, and protect the buffer access.
-    //		
-    /// @brief : Describes a range of bytes within a Device Buffer.
-    //----------------------------------------------------------------------------------------------------
-    struct DeviceBufferRange
-    {
-        DeviceBuffer*       m_buffer = nullptr;     // Buffer Resource.
-        uint64              m_offset = 0;           // Byte offset in the buffer.
-        uint64              m_range = 0;            // Number of bytes in the range.
-        uint64              m_deviceAddress = 0;    // Must contain the offset already.
-        uint8*              m_pMapping = nullptr;   // Must contain the offset already.
-    };
-
-    //----------------------------------------------------------------------------------------------------
     // [TODO]: Right now, I am allocating a single staging buffer per appended buffer copy. I should instead
     //  queue up all upload operations at once, then create a single staging buffer, save the ranges that I
     //  need to copy from and perform the copy commands using that single source buffer.

--- a/Source/Engine/Nessie/Graphics/DeviceBuffer.h
+++ b/Source/Engine/Nessie/Graphics/DeviceBuffer.h
@@ -69,6 +69,8 @@ namespace nes
         void                    FreeBuffer();
 
     private:
+        friend class DeviceBufferRange;
+        
         RenderDevice*           m_pDevice = nullptr;
         BufferDesc              m_desc{};                   // Buffer properties.
         vk::Buffer              m_buffer = nullptr;         // Vulkan handle.
@@ -76,6 +78,6 @@ namespace nes
         uint8*                  m_pMappedMemory = nullptr;  // CPU mapped memory. 
         VmaAllocation           m_allocation = nullptr;     // Memory associated with the buffer.
     };
-
+    
     static_assert(DeviceObjectType<DeviceBuffer>);
 }

--- a/Source/Tests/Rectangle/RectangleApp.cpp
+++ b/Source/Tests/Rectangle/RectangleApp.cpp
@@ -78,8 +78,8 @@ bool RectangleApp::Internal_AppInit()
             desc.m_usage = nes::EBufferUsageBits::IndexBuffer | nes::EBufferUsageBits::VertexBuffer;
             m_geometryBuffer = nes::DeviceBuffer(device, desc);
             
-            m_vertexBufferDesc = nes::VertexBufferDesc(&m_geometryBuffer, sizeof(Vertex), 0);
-            m_indexBufferDesc = nes::IndexBufferDesc(&m_geometryBuffer, nes::EIndexType::U16, vertexBufferSize);
+            m_vertexBufferDesc = nes::VertexBufferRange(&m_geometryBuffer, sizeof(Vertex), vertices.size());
+            m_indexBufferDesc = nes::IndexBufferRange(&m_geometryBuffer, indices.size(), nes::EIndexType::U16, vertexBufferSize);
         }
 
         // Upload the vertex and index data to the buffer.
@@ -192,7 +192,7 @@ void RectangleApp::Internal_AppRender(nes::CommandBuffer& commandBuffer, const n
         // Draw the rectangle:
         commandBuffer.BindIndexBuffer(m_indexBufferDesc);
         commandBuffer.BindVertexBuffers(m_vertexBufferDesc);
-        commandBuffer.DrawIndexed(6);
+        commandBuffer.DrawIndexed(m_indexBufferDesc.GetNumIndices());
 
         // Finish.
         commandBuffer.EndRendering();

--- a/Source/Tests/Rectangle/RectangleApp.h
+++ b/Source/Tests/Rectangle/RectangleApp.h
@@ -31,7 +31,7 @@ private:
     nes::PipelineLayout     m_pipelineLayout = nullptr;
     nes::Pipeline           m_pipeline = nullptr;
     nes::DeviceBuffer       m_geometryBuffer = nullptr;
-    nes::IndexBufferDesc    m_indexBufferDesc = {};
-    nes::VertexBufferDesc   m_vertexBufferDesc = {};
+    nes::IndexBufferRange   m_indexBufferDesc = {};
+    nes::VertexBufferRange  m_vertexBufferDesc = {};
     nes::DeviceQueue*       m_pTransferQueue = nullptr;
 };


### PR DESCRIPTION
I realized that vertex and index buffers are just views into a device buffer resource. So, I created the `DeviceBufferRange` class, which is analogous to a std::span. The `VertexBufferRange` and `IndexBufferRange` are subclasses that contain more specific information about the range and can be used for draw calls.

Having these terms makes it more clear that you can use a single `DeviceBuffer` for multiple ranges of data.