### PR TITLE
Started Mip Map Generation

### DIFF
--- a/Source/Engine/Nessie/Graphics/CommandBuffer.cpp
+++ b/Source/Engine/Nessie/Graphics/CommandBuffer.cpp
@@ -217,8 +217,8 @@ namespace nes
                 .setStoreOp(vk::AttachmentStoreOp::eStore)
                 .setClearValue({});
 
-            const uint16 width = desc.m_pImage->GetSize(0, desc.m_mipOffset);
-            const uint16 height = desc.m_pImage->GetSize(1, desc.m_mipOffset);
+            const uint16 width = desc.m_pImage->GetDimensionSize(0, desc.m_mipOffset);
+            const uint16 height = desc.m_pImage->GetDimensionSize(1, desc.m_mipOffset);
 
             m_renderLayerCount = math::Min(m_renderLayerCount, desc.m_layerCount);
             m_renderWidth = math::Min(m_renderWidth, width);
@@ -242,8 +242,8 @@ namespace nes
                 .setStoreOp(vk::AttachmentStoreOp::eStore)
                 .setClearValue({});
 
-            const uint16 width = desc.m_pImage->GetSize(0, desc.m_mipOffset);
-            const uint16 height = desc.m_pImage->GetSize(1, desc.m_mipOffset);
+            const uint16 width = desc.m_pImage->GetDimensionSize(0, desc.m_mipOffset);
+            const uint16 height = desc.m_pImage->GetDimensionSize(1, desc.m_mipOffset);
             
             m_renderLayerCount = math::Min(m_renderLayerCount, desc.m_layerCount);
             m_renderWidth = math::Min(m_renderWidth, width);

--- a/Source/Engine/Nessie/Graphics/DeviceImage.h
+++ b/Source/Engine/Nessie/Graphics/DeviceImage.h
@@ -5,6 +5,33 @@
 
 namespace nes
 {
+    namespace graphics
+    {
+        //----------------------------------------------------------------------------------------------------
+        /// @brief : Calculate the maximum number of mip levels for a 1D image. 
+        //----------------------------------------------------------------------------------------------------
+        inline uint32 CalculateMipLevelCount(const uint32 extent)
+        {
+            return static_cast<uint32>(std::floor(std::log2(extent))) + 1; 
+        }
+
+        //----------------------------------------------------------------------------------------------------
+        /// @brief : Calculate the maximum number of mip levels for a 2D image. 
+        //----------------------------------------------------------------------------------------------------
+        inline uint32 CalculateMipLevelCount(const uint32 width, const uint32 height)
+        {
+            return static_cast<uint32>(std::floor(std::log2(math::Max(width, height)))) + 1; 
+        }
+
+        //----------------------------------------------------------------------------------------------------
+        /// @brief : Calculate the maximum number of mip levels for a 3D image. 
+        //----------------------------------------------------------------------------------------------------
+        inline uint32 CalculateMipLevelCount(const uint32 width, const uint32 height, const uint32 depth)
+        {
+            return static_cast<uint32>(std::floor(std::log2(math::Max(width, height, depth)))) + 1; 
+        }
+    }
+    
     //----------------------------------------------------------------------------------------------------
     /// @brief : A Device image is the device resource for a Texture.
     ///      It represents a multidimensional array of data (1D, 2D or 3D).
@@ -49,18 +76,25 @@ namespace nes
         //----------------------------------------------------------------------------------------------------
         /// @brief : Get the Vulkan Image object.
         //----------------------------------------------------------------------------------------------------
-        vk::Image           GetVkImage() const      { return m_image; } 
+        vk::Image           GetVkImage() const      { return m_image; }
+
+        //----------------------------------------------------------------------------------------------------
+        /// @brief : Get the number of pixels for a particular mip level. Mip level 0 is used by default,
+        ///     which is the original image.
+        //----------------------------------------------------------------------------------------------------
+        uint64              GetPixelCount(const uint16 mipLevel = 0) const;
+
+        //----------------------------------------------------------------------------------------------------
+        /// @brief : Get the number of bytes in a single pixel. 
+        //----------------------------------------------------------------------------------------------------
+        uint64              GetPixelSize() const;
 
         //----------------------------------------------------------------------------------------------------
         /// @brief : Get the size of a particular dimension (width = 0, height = 1, depth = 2) for a given mip level.
+        ///     Mip level 0 is used by default, which is the original image.
         //----------------------------------------------------------------------------------------------------
-        uint16              GetSize(const uint16 dimensionIndex, const uint16 mip = 0) const;
-
-        //----------------------------------------------------------------------------------------------------
-        /// @brief : Get the number of pixels in the first mip level. 
-        //----------------------------------------------------------------------------------------------------
-        uint64              GetPixelCount() const;
-
+        uint16              GetDimensionSize(const uint16 dimensionIndex, const uint32 mipLevel = 0) const;
+        
         //----------------------------------------------------------------------------------------------------
         /// @brief : Advanced use. Get the native vulkan object handle, and the type.
         //----------------------------------------------------------------------------------------------------

--- a/Source/Engine/Nessie/Graphics/GraphicsCommon.h
+++ b/Source/Engine/Nessie/Graphics/GraphicsCommon.h
@@ -316,7 +316,7 @@ namespace nes
     struct ImageBarrierDesc
     {
         //----------------------------------------------------------------------------------------------------
-        /// @brief : Set the image that will be transitioned. 
+        /// @brief : Set the image that will be transitioned.
         //----------------------------------------------------------------------------------------------------
         ImageBarrierDesc&   SetImage(DeviceImage* pImage);
 
@@ -389,9 +389,9 @@ namespace nes
 
     enum class EImageType : uint8
     {
-        Image1D,
-        Image2D,
-        Image3D,
+        Image1D,    // Single buffer of pixel data.
+        Image2D,    // 2D buffer of pixel data, used for Textures.
+        Image3D,    // 3D buffer of pixel data.
         MaxNum
     };
 
@@ -446,19 +446,22 @@ namespace nes
     };
     NES_DEFINE_BIT_OPERATIONS_FOR_ENUM(EBufferUsageBits);
 
+    //----------------------------------------------------------------------------------------------------
+    /// @brief : Properites of a DeviceImage. 
+    //----------------------------------------------------------------------------------------------------
     struct ImageDesc
     {
-        EImageType          m_type = EImageType::Image2D;
-        EImageUsageBits     m_usage = EImageUsageBits::ShaderResource;
-        EFormat             m_format = EFormat::Unknown;
-        uint32              m_width = 1;
-        uint32              m_height = 1;
-        uint32              m_depth = 1;
-        uint32              m_mipCount = 1;
-        uint32              m_layerCount = 1;
-        uint32              m_sampleCount = 1;
-        ESharingMode        m_sharingMode = ESharingMode::Exclusive;
-        ClearValue          m_clearValue{};
+        EImageType          m_type = EImageType::Image2D;               // Type of image that this resource is.
+        EImageUsageBits     m_usage = EImageUsageBits::ShaderResource;  // How the image will be used.
+        EFormat             m_format = EFormat::Unknown;                // The pixel format of the image.
+        uint32              m_width = 1;                                // Width of the image, in pixels.
+        uint32              m_height = 1;                               // Height of the image, in pixels.
+        uint32              m_depth = 1;                                // Depth of the image, in pixels.
+        uint32              m_mipCount = 1;                             // Number of mip levels. Mip Level 0 is the original image, and subsequent levels are copies of the image with dimensions cut in half. They can be thought of as Level of Detail.
+        uint32              m_layerCount = 1;                           // Number of layers for the image.
+        uint32              m_sampleCount = 1;                          // Used for multisampling.
+        ESharingMode        m_sharingMode = ESharingMode::Exclusive;    // Defines if this image can be used across multiple device queues.
+        ClearValue          m_clearValue{};                             // Values to use when clearing this image.
 
         //----------------------------------------------------------------------------------------------------
         /// @brief : Ensures that ranges are valid. 
@@ -467,11 +470,7 @@ namespace nes
     };
 
     //----------------------------------------------------------------------------------------------------
-    /// @brief : Used to create a buffer resource.
-    //  Available "m_structuredStride" Values:
-    //      0   = allows "typed" views.
-    //      4   = allows "types", "byte address" (raw) and "structured" views.
-    //      >4  = allows "structured" and potentially "typed" views.
+    /// @brief : Properties of a Device Buffer.
     //----------------------------------------------------------------------------------------------------
     struct BufferDesc
     {

--- a/Source/Engine/Nessie/Graphics/Texture.cpp
+++ b/Source/Engine/Nessie/Graphics/Texture.cpp
@@ -51,6 +51,9 @@ namespace nes
         
         m_imageData = Buffer(pData, width * height * STBI_rgb_alpha);
 
+        // [TODO]: Allow custom number of mip levels from metadata.
+        //const uint32 mipLevels = graphics::CalculateMipLevelCount(static_cast<uint32>(width), static_cast<uint32>(height));     
+
         // Texture Description
         ImageDesc textureDesc{};
         textureDesc.m_width = math::Max(static_cast<uint32>(width), 1U);
@@ -58,8 +61,8 @@ namespace nes
         textureDesc.m_depth = 1;
         textureDesc.m_format = EFormat::RGBA8_UNORM;
         textureDesc.m_layerCount = 1;
-        textureDesc.m_mipCount = 1;    // [TODO]: Mip Levels
-        textureDesc.m_sampleCount = 1;
+        textureDesc.m_mipCount = 1; // // [TODO]: mipLevels from file - not calculated.
+        textureDesc.m_sampleCount = 1; // [TODO]: Multisampling
         textureDesc.m_type = EImageType::Image2D;
         textureDesc.m_usage = EImageUsageBits::ShaderResource;
         textureDesc.m_clearValue = ClearValue{}; 
@@ -76,18 +79,26 @@ namespace nes
         auto& device = DeviceManager::GetRenderDevice();
         m_image = DeviceImage(device, allocDesc);
         
-        // Upload image data:
-        DataUploader dataUploader(Renderer::GetDevice());
         auto cmdBuffer = Renderer::BeginTempCommands();
         {
+            // Upload image data:
+            DataUploader dataUploader(Renderer::GetDevice());
             ImageUploadDesc uploadDesc{};
             uploadDesc.m_uploadSize = m_imageData.GetSize();
             uploadDesc.m_pPixelData = m_imageData.Get();
             uploadDesc.m_pImage = &m_image;
             uploadDesc.m_newLayout = EImageLayout::ShaderResource;
             dataUploader.AppendUploadImage(uploadDesc);
-        
             dataUploader.RecordCommands(cmdBuffer);
+
+            // [TODO]: Uploading Mip Map data:
+            // Turns out, the image blitting method that I started with isn't the best option - I should use a stb_image_resize2.h to
+            // create the mip map levels that I need instead of relying on the blit image. Not all formats are
+            // supported by blit image, and the command has to be submitted on a device queue with graphics capabilities.
+            // - When importing a texture into the Engine Application, mip maps should be generated and stored in a single file, with
+            // a base level and count at the beginning of the binary file.
+            
+            // Submit commands:
             Renderer::SubmitAndWaitTempCommands(cmdBuffer);
         }
         

--- a/Source/Tests/Rectangle/RectangleApp.cpp
+++ b/Source/Tests/Rectangle/RectangleApp.cpp
@@ -324,7 +324,7 @@ void RectangleApp::CreateDescriptorSets(nes::RenderDevice& device)
     imageViewDesc.m_baseLayer = 0;
     imageViewDesc.m_layerCount = 1;
     imageViewDesc.m_baseMipLevel = 0;
-    imageViewDesc.m_mipCount = 1;
+    imageViewDesc.m_mipCount = static_cast<uint16>(desc.m_mipCount);
     imageViewDesc.m_format = desc.m_format;
     imageViewDesc.m_viewType = nes::EImage2DViewType::ShaderResource2D;
     m_imageView = nes::Descriptor(device, imageViewDesc);


### PR DESCRIPTION
I went through and implemented a image blitting method from the Vulkan tutorial, however, image blitting needs to be submitted to a graphics queue (I am generating mip maps on the Asset Thread, which will be using a transfer queue) and blitting is not supported by all image formats.

The solution is to generate the mip maps beforehand and store them in Texture Asset file itself, and then upload data to each level accordingly.

I removed access to it, but I left the GenerateMipMaps function in there for reference in the future.

I added some comments to the image description object, and documented what I need to do later.