### PR TITLE
Fixed No Game Camera Crash

### DIFF
--- a/Content/Worlds/PBRTestWorld.yaml
+++ b/Content/Worlds/PBRTestWorld.yaml
@@ -186,6 +186,7 @@ World:
               ShutterSpeed: 125
               Iso: 100
               ProjectionType: 0
+            IsActive: true
         - TransformComponent:
             Position: [4.2, 2.1, 6.252]
             Rotation: [4, -47, 0]

--- a/Source/Engine/Nessie/Editor/Inspectors/Components/CameraComponentInspector.cpp
+++ b/Source/Engine/Nessie/Editor/Inspectors/Components/CameraComponentInspector.cpp
@@ -1,10 +1,11 @@
 ﻿// CameraComponentInspector.cpp
 #include "CameraComponentInspector.h"
 #include "Nessie/Editor/PropertyTable.h"
+#include "Nessie/World/WorldBase.h"
 
 namespace nes
 {
-    void CameraComponentInspector::DrawImpl(CameraComponent* pTarget, const InspectorContext&)
+    void CameraComponentInspector::DrawImpl(CameraComponent* pTarget, const InspectorContext& context)
     {
         auto& camera = pTarget->m_camera;
 
@@ -57,5 +58,13 @@ namespace nes
              "\n- Slow Speed (1/30s, 1) = more light.");
 
         editor::Property("ISO", camera.m_iso, 1.f, 1.f, FLT_MAX, "%.0f", "Sensor sensitivity. Acts as a linear brightness multiplier.");
+
+        // Active State:
+        if (editor::Property("IsActive", pTarget->m_isActive, "Set whether this camera is the active camera in the scene. If this is the only camera in the scene, it will remain active."))
+        {
+            // [Hack]:
+            // Only one entity can be inspected at once right now, so I can just set it here: 
+            context.m_pWorld->GetRenderer()->SetActiveCameraEntity(context.m_selectionIDs[0]); 
+        }
     }
 }

--- a/Source/Engine/Nessie/Editor/PropertyTable.cpp
+++ b/Source/Engine/Nessie/Editor/PropertyTable.cpp
@@ -210,6 +210,30 @@ namespace nes::editor
         internal::EndProperty();
     }
 
+    bool Property(const char* label, bool& value, const char* toolTip)
+    {
+        internal::BeginProperty(label, toolTip);
+        internal::BeginPropertyValue();
+        
+        const bool modified = ImGui::Checkbox(internal::CreateHiddenPropertyValueLabel(label).c_str(), &value);
+        
+        internal::EndPropertyValue();
+        internal::EndProperty();
+        
+        return modified;
+    }
+
+    void Property(const char* label, const bool& value, const char* toolTip)
+    {
+        internal::BeginProperty(label, toolTip);
+
+        internal::BeginPropertyValue(true);
+        ImGui::Checkbox(internal::CreateHiddenPropertyValueLabel(label).c_str(), const_cast<bool*>(&value));
+        internal::EndPropertyValue(true);
+        
+        internal::EndProperty();
+    }
+
     bool Property(const char* label, int& value, const char* toolTip)
     {
         internal::BeginProperty(label, toolTip);

--- a/Source/Engine/Nessie/Editor/PropertyTable.h
+++ b/Source/Engine/Nessie/Editor/PropertyTable.h
@@ -119,6 +119,23 @@ namespace nes::editor
     void Property(const char* label, const std::string& value, const char* toolTip = "");
 
     //----------------------------------------------------------------------------------------------------
+    /// @brief : Render a boolean checkbox property that can be edited.
+    ///	@param label : Name of the property.
+    ///	@param value : Value to edit.
+    ///	@param toolTip : Optional tooltip that will show up when hovering over the name of the property.
+    ///	@returns : Returns true if the value has changed.
+    //----------------------------------------------------------------------------------------------------
+    bool Property(const char* label, bool& value, const char* toolTip = "");
+
+    //----------------------------------------------------------------------------------------------------
+    /// @brief : Render a boolean checkbox property, but disable any edits.
+    ///	@param label : Name of the property.
+    ///	@param value : Value to show.
+    ///	@param toolTip : Optional tooltip that will show up when hovering over the name of the property.
+    //----------------------------------------------------------------------------------------------------
+    void Property(const char* label, const bool& value, const char* toolTip = "");
+
+    //----------------------------------------------------------------------------------------------------
     /// @brief : Render an int property that can be edited.
     ///	@param label : Name of the property.
     ///	@param value : Value to edit.

--- a/Source/Engine/Nessie/World/ComponentSystems/FreeCamSystem.h
+++ b/Source/Engine/Nessie/World/ComponentSystems/FreeCamSystem.h
@@ -11,8 +11,8 @@ namespace nes
     
     struct FreeCamMovementComponent
     {
-        float       m_moveSpeed = 50.f;      // m/s.
-        float       m_sensitivity = 1.25f;
+        float       m_moveSpeed = 20.f;      // m/s.
+        float       m_sensitivity = 0.25f;
 
         static void Serialize(YamlOutStream& out, const FreeCamMovementComponent& component);
         static void Deserialize(const YamlNode& in, FreeCamMovementComponent& component);

--- a/Source/Engine/Nessie/World/Components/CameraComponent.cpp
+++ b/Source/Engine/Nessie/World/Components/CameraComponent.cpp
@@ -8,10 +8,12 @@ namespace nes
     void CameraComponent::Serialize(YamlOutStream& out, const CameraComponent& component)
     {
         CameraSerializer::Serialize(out, component.m_camera);
+        out.Write("IsActive", component.m_isActive);
     }
 
     void CameraComponent::Deserialize(const YamlNode& in, CameraComponent& component)
     {
         CameraSerializer::Deserialize(in, component.m_camera);
+        in["IsActive"].Read(component.m_isActive, true);
     }
 }

--- a/Source/Engine/Nessie/World/Components/CameraComponent.h
+++ b/Source/Engine/Nessie/World/Components/CameraComponent.h
@@ -9,6 +9,7 @@ namespace nes
     struct CameraComponent
     {
         Camera          m_camera{};
+        bool            m_isActive = true;
 
         //----------------------------------------------------------------------------------------------------
         /// @brief : Calculates the projection matrix, which will be either Perspective or Orthographic depending

--- a/Source/Engine/Nessie/World/WorldRenderer.cpp
+++ b/Source/Engine/Nessie/World/WorldRenderer.cpp
@@ -5,7 +5,7 @@ namespace nes
 {
     void WorldRenderer::RenderWorld(CommandBuffer& commandBuffer, const RenderFrameContext& context)
     {
-        WorldCamera camera = GetActiveCamera();
+        const WorldCamera camera = GetActiveCamera();
         RenderWorldWithCamera(camera, commandBuffer, context);
     }
 }

--- a/Source/Engine/Nessie/World/WorldRenderer.h
+++ b/Source/Engine/Nessie/World/WorldRenderer.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "ComponentSystem.h"
 #include "WorldCamera.h"
+#include "Components/IDComponent.h"
 #include "Nessie/Graphics/Renderer.h"
 
 namespace nes
@@ -15,7 +16,8 @@ namespace nes
         virtual void            RenderWorldWithCamera(const WorldCamera& worldCamera, CommandBuffer& commandBuffer, const RenderFrameContext& context) = 0;
         virtual RenderTarget*   GetFinalColorTarget() = 0;
         virtual RenderTarget*   GetFinalDepthTarget() = 0;
-        virtual WorldCamera     GetActiveCamera() const = 0;
+        virtual WorldCamera     GetActiveCamera() = 0;
+        virtual void            SetActiveCameraEntity(const nes::EntityID& id) = 0;
         virtual void            OnViewportResize(const uint32 width, const uint32 height) = 0;
     };
 }

--- a/Source/Tests/PBR/ComponentSystems/PBRSceneRenderer.h
+++ b/Source/Tests/PBR/ComponentSystems/PBRSceneRenderer.h
@@ -35,7 +35,8 @@ namespace pbr
 
         // WorldRenderer API:
         virtual void                    RenderWorldWithCamera(const nes::WorldCamera& worldCamera, nes::CommandBuffer& commandBuffer, const nes::RenderFrameContext& context) override;
-        virtual nes::WorldCamera        GetActiveCamera() const override;
+        virtual nes::WorldCamera        GetActiveCamera() override;
+        virtual void                    SetActiveCameraEntity(const nes::EntityID& id) override;
         virtual nes::RenderTarget*      GetFinalColorTarget() override { return &m_colorTarget; }
         virtual nes::RenderTarget*      GetFinalDepthTarget() override { return nullptr; }
         virtual void                    OnViewportResize(const uint32 width, const uint32 height) override;
@@ -216,6 +217,7 @@ namespace pbr
         nes::RenderTarget               CreateColorRenderTarget(const nes::YamlNode& targetNode, const std::string& name, nes::RenderDevice& device, const nes::EFormat swapchainFormat, const nes::UInt2 swapchainExtent);
         nes::RenderTarget               LoadDepthRenderTarget(const nes::YamlNode& targetNode, const std::string& name, nes::RenderDevice& device, const nes::UInt2 swapchainExtent);
         void                            LoadGraphicsPipeline(const nes::YamlNode& pipelineNode, nes::RenderDevice& device, nes::PipelineLayout& outLayout, nes::Pipeline& outPipeline) const;
+        void                            TryFindCameraToActivate();
 
     private:
         // Default AssetIDs - Set during initialization.


### PR DESCRIPTION
If you ran the game and deleted the in-game camera, I now ensure that if we are clearing the active camera Entity ID that was previously set, I am finding the next available camera by scoring the available cameras in the word.
- Added a boolean checkbox property.
- Set the default values of the Free Cam Movement Component to be more in line with the editor camera.